### PR TITLE
Add mobile layout with play and back buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,19 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ru">
 <head>
   <meta charset="UTF-8">
   <title>NY Game</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>NY Game</h1>
-  <button id="colorButton">Change background</button>
+  <div id="app">
+    <div id="menu">
+      <button id="playButton">Играть</button>
+    </div>
+    <div id="game" class="hidden">
+      <button id="backButton">Назад</button>
+    </div>
+  </div>
   <script src="scripts.js"></script>
 </body>
 </html>

--- a/scripts.js
+++ b/scripts.js
@@ -1,7 +1,16 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const button = document.getElementById('colorButton');
-  button.addEventListener('click', () => {
-    const color = '#' + Math.floor(Math.random() * 16777215).toString(16);
-    document.body.style.backgroundColor = color;
+  const menu = document.getElementById('menu');
+  const game = document.getElementById('game');
+  const playButton = document.getElementById('playButton');
+  const backButton = document.getElementById('backButton');
+
+  playButton.addEventListener('click', () => {
+    menu.classList.add('hidden');
+    game.classList.remove('hidden');
+  });
+
+  backButton.addEventListener('click', () => {
+    game.classList.add('hidden');
+    menu.classList.remove('hidden');
   });
 });

--- a/style.css
+++ b/style.css
@@ -14,8 +14,50 @@
 
 body {
   font-family: 'VelaSans', sans-serif;
-  text-align: center;
-  padding-top: 50px;
+  background-color: #e0e0e0;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+#app {
+  background-color: #fff;
+  border: 1px solid #ccc;
+  width: 100%;
+  height: 100%;
+  min-width: 360px;
+  max-width: 440px;
+  min-height: 640px;
+  max-height: 956px;
+  box-sizing: border-box;
+}
+
+#menu,
+#game {
+  width: 100%;
+  height: 100%;
+}
+
+#menu {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+#game {
+  position: relative;
+}
+
+#backButton {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+}
+
+.hidden {
+  display: none;
 }
 
 button {


### PR DESCRIPTION
## Summary
- Create mobile-friendly interface container with grey border and light grey background
- Add Play and Back buttons to toggle between menu and game views

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68c7d0be7d14832a86d98d8e8c0b151e